### PR TITLE
Added support for manifests in UTF-16 LE BOM format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamestore-origin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Discovery and game launch support for the Origin/EA game store",
   "main": "./out/index.js",
   "repository": "",
@@ -11,7 +11,7 @@
   "author": "Black Tree Gaming Ltd.",
   "license": "GPL-3.0",
   "devDependencies": {
-    "@types/libxmljs": "^0.18.4",
+    "@types/xml2js": "^0.4.11",
     "bluebird": "^3.5.0",
     "ts-loader": "^6.0.4",
     "turbowalk": "Nexus-Mods/node-turbowalk",
@@ -19,6 +19,7 @@
     "vortex-api": "Nexus-Mods/vortex-api",
     "webpack": "^4.35.0",
     "webpack-cli": "^3.3.10",
-    "winapi-bindings": "Nexus-Mods/node-winapi-bindings"
+    "winapi-bindings": "Nexus-Mods/node-winapi-bindings",
+    "xml2js": "^0.4.23"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,12 +123,14 @@ class OriginLauncher implements types.IGameStore {
     });
   }
 
-  private async getGameName(installerPath: string, manifestType: ManifestType): Promise<string> {
-    const installerData = await fs.readFileAsync(installerPath)
+  private async getGameName(installerPath: string, manifestType: ManifestType, customEncoding?: 'ucs2'): Promise<string> {
+    const installerData = await fs.readFileAsync(installerPath, { encoding: customEncoding || 'utf8' });
     let xmlDoc;
     try {
       xmlDoc = await parseStringPromise(installerData);
     } catch (err) {
+      // For some reason, some of the Origin manifests can be encoded as UTF-16 LE BOM which means we'd need to parse the file as ucs2, not utf8.
+      if (!customEncoding && err.message.includes('Non-whitespace before first tag.')) return this.getGameName(installerPath, manifestType, 'ucs2');
       return Promise.reject(err);
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,5 @@ let webpack = require('vortex-api/bin/webpack').default;
 const config = webpack('gamestore-origin', __dirname, 4);
 
 config.externals.turbowalk = 'turbowalk';
-config.externals.libxmljs = 'libxmljs';
 
 module.exports = config;


### PR DESCRIPTION
It appears some manifests from Origin are not UTF-8 but UTF-16 LE BOM. This results in the following error in the Vortex log on parsing:
```
Sun, 10 Jul 2022 18:49:23 GMT - error: [gamestore-origin] failed to find game name for OFB-EAST:52209 , , length=2
```

This PR catches this error case and reparses the manifest file under `ucs2` encoding to attempt to adapt to this error case. If the second read also fails, an error will throw as normal. 

Example of the manifest used in testing is attached. 

[installerdata.zip](https://github.com/Nexus-Mods/extension-gamestore-origin/files/9079795/installerdata.zip)

This PR also removes leftover references to `libxmljs` which has been replaced by `xml2js` across the app. Updated the package.json file with the relevant modules. 
